### PR TITLE
NetCDF plus other changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 Imports:
 	ecmwfr (>= 1.3.0),
-	sf (>= 1.9-8),
+	sf (>= 1.0-3),
   dplyr (>= 1.0.6),
   stringr (>= 1.4.0),
-  stars (>= 1.5-2)
+  stars (>= 0.5-3)

--- a/R/download.R
+++ b/R/download.R
@@ -13,7 +13,8 @@
 #' @param key your api key as a string
 #' @param format format of the data. `"netcdf"` (default) or `"grib"`
 #' @param download_dir download directory
-#'
+#' @param ... further parameters passed to [ecmwfr::wf_request()]
+#' #'
 #' @return A matrix of the infile
 #' @export
 
@@ -27,15 +28,14 @@ era5land_download_hourly <- function(aoi = aoi,
                                  user = "",
                                  key = "",
                                  download_dir = ".",
-                                 format = c("netcdf", "grib")){
+                                 format = c("netcdf", "grib"),
+                                 ...){
 
   format <- match.arg(format)
 
   ### AUTHENTICATE ####
 
-  ecmwfr::wf_set_key(user = user,
-             key = key,
-             service = "cds")
+  cds_auth(user)
 
   #### FORMAT REQUEST ####
 
@@ -65,14 +65,11 @@ era5land_download_hourly <- function(aoi = aoi,
                    min(hours),"-",
                    max(hours),"h_",
                    length(variables),
-                   "vars.", format)
+                   "vars.", ext)
 
   # FORMAT BOUNDS
 
-  bounds = paste(sf::st_bbox(aoi)[4] %>% as.numeric() %>% round(2),
-                 sf::st_bbox(aoi)[1] %>% as.numeric() %>% round(2),
-                 sf::st_bbox(aoi)[2] %>% as.numeric() %>% round(2),
-                 sf::st_bbox(aoi)[3] %>% as.numeric() %>% round(2), sep = "/")
+  bounds = format_bounds(aoi)
 
   # Setup request
   request <- list("dataset_short_name" = 'reanalysis-era5-land',
@@ -89,7 +86,8 @@ era5land_download_hourly <- function(aoi = aoi,
   file <- ecmwfr::wf_request(user     = user,
                      request  = request,
                      transfer = TRUE,
-                     path     = download_dir)
+                     path     = download_dir,
+                     ...)
 
   return(file)
   }
@@ -98,18 +96,9 @@ era5land_download_hourly <- function(aoi = aoi,
 #'
 #' This function
 #'
-#' @param aoi any sf object
-#' @param aoi_name string
-#' @param years numeric from 1979-2021
-#' @param months numeric from 1-12
-#' @param variables 'surface_net_solar_radiation','2m_temperature','total_precipitation','snow_depth_water_equivalent', ...
-#' @param user your user id as a string
-#' @param key your api key as a string
-#' @param download_dir download directory
+#' @inheritParams era5land_download_hourly
 #' @return A matrix of the infile
 #' @export
-
-
 
 era5land_download_monthly <- function(aoi = aoi,
                                   aoi_name = name,
@@ -117,14 +106,15 @@ era5land_download_monthly <- function(aoi = aoi,
                                   months = 5:8,
                                   variables = c('2m_temperature', 'total_precipitation'),
                                   user = "",
-                                  key = "",
-                                  download_dir = "."){
+                                  download_dir = ".",
+                                  format = c("netcdf", "grib"),
+                                  ...){
+
+  format <- match.arg(format)
 
   ### AUTHENTICATE ####
 
-  ecmwfr::wf_set_key(user = user,
-             key = key,
-             service = "cds")
+  cds_auth(user)
 
   #### FORMAT REQUEST ####
 
@@ -134,6 +124,8 @@ era5land_download_monthly <- function(aoi = aoi,
   # Format months
   months <- stringr::str_pad(string = months, width = 2, side = "left", pad = 0)
 
+  ext <- ifelse(format == "netcdf", "nc", "grib")
+
   # Out name
   target <- paste0("ERA5-land-monthly_",
                    aoi_name, "_",
@@ -141,14 +133,12 @@ era5land_download_monthly <- function(aoi = aoi,
                    max(years),"y_",
                    min(months),"-",
                    max(months),"m_",
-                   length(variables),"vars.grib")
+                   length(variables),
+                   "vars.", ext)
 
   # FORMAT BOUNDS
 
-  bounds = paste(sf::st_bbox(aoi)[4] %>% as.numeric() %>% round(0),
-                 sf::st_bbox(aoi)[1] %>% as.numeric() %>% round(0),
-                 sf::st_bbox(aoi)[2] %>% as.numeric() %>% round(0),
-                 sf::st_bbox(aoi)[3] %>% as.numeric() %>% round(0), sep = "/")
+  bounds = format_bounds(aoi)
 
   # Setup request
   request <- list("dataset_short_name" = 'reanalysis-era5-land-monthly-means',
@@ -158,13 +148,34 @@ era5land_download_monthly <- function(aoi = aoi,
                   "month" = months,
                   "time" = "00:00",
                   "area" = bounds,
-                  "format" = "grib",
+                  "format" = format,
                   "target" = target)
 
-  file <- ecmwfr::wf_request(user     = user,
+  file <- ecmwfr::wf_request(user = user,
                      request  = request,
                      transfer = TRUE,
-                     path     = download_dir)
+                     path     = download_dir,
+                     ...)
 
   return(file)
+}
+
+cds_auth <- function(user) {
+  if (!nzchar(user)) stop("PLease specify your user id")
+
+  keytry <- try(ecmwfr::wf_get_key(user = user, service = "cds"))
+
+  if (inherits(keytry, "try-error")) {
+    stop("You have not set your API key. Please do so with",
+         "ecmwfr::sf_set_key()")
+  }
+
+  invisible(TRUE)
+}
+
+format_bounds <- function(aoi) {
+  paste(sf::st_bbox(aoi)[4] %>% as.numeric() %>% round(2),
+        sf::st_bbox(aoi)[1] %>% as.numeric() %>% round(2),
+        sf::st_bbox(aoi)[2] %>% as.numeric() %>% round(2),
+        sf::st_bbox(aoi)[3] %>% as.numeric() %>% round(2), sep = "/")
 }

--- a/R/download.R
+++ b/R/download.R
@@ -11,12 +11,14 @@
 #' @param variables 'surface_net_solar_radiation','2m_temperature','total_precipitation','snow_depth_water_equivalent', ...
 #' @param user your user id as a string
 #' @param key your api key as a string
+#' @param format format of the data. `"netcdf"` (default) or `"grib"`
 #' @param download_dir download directory
+#'
 #' @return A matrix of the infile
 #' @export
 
 era5land_download_hourly <- function(aoi = aoi,
-                                 aoi_name = name,
+                                 aoi_name = "name",
                                  years = 2021:2021,
                                  months = 5:8,
                                  days = 1:31,
@@ -24,7 +26,10 @@ era5land_download_hourly <- function(aoi = aoi,
                                  variables = c('surface_net_solar_radiation'),
                                  user = "",
                                  key = "",
-                                 download_dir = "."){
+                                 download_dir = ".",
+                                 format = c("netcdf", "grib")){
+
+  format <- match.arg(format)
 
   ### AUTHENTICATE ####
 
@@ -46,6 +51,8 @@ era5land_download_hourly <- function(aoi = aoi,
   # Format time
   hours <- paste0(stringr::str_pad(string = hours, width = 2, side = "left", pad = "0"),":00") # MAX 23
 
+  ext <- ifelse(format == "netcdf", "nc", "grib")
+
   # Out name
   target <- paste0("ERA5-land-hourly_",
                    aoi_name, "_",
@@ -57,7 +64,8 @@ era5land_download_hourly <- function(aoi = aoi,
                    max(days),"d_",
                    min(hours),"-",
                    max(hours),"h_",
-                   length(variables),"vars.grib")
+                   length(variables),
+                   "vars.", format)
 
   # FORMAT BOUNDS
 
@@ -75,7 +83,7 @@ era5land_download_hourly <- function(aoi = aoi,
                   "day" = days,
                   "time" = hours,
                   "area" = bounds,
-                  "format" = "grib",
+                  "format" = format,
                   "target" = target)
 
   file <- wf_request(user     = user,

--- a/R/download.R
+++ b/R/download.R
@@ -33,7 +33,7 @@ era5land_download_hourly <- function(aoi = aoi,
 
   ### AUTHENTICATE ####
 
-  wf_set_key(user = user,
+  ecmwfr::wf_set_key(user = user,
              key = key,
              service = "cds")
 
@@ -69,10 +69,10 @@ era5land_download_hourly <- function(aoi = aoi,
 
   # FORMAT BOUNDS
 
-  bounds = paste(st_bbox(aoi)[4] %>% as.numeric() %>% round(2),
-                 st_bbox(aoi)[1] %>% as.numeric() %>% round(2),
-                 st_bbox(aoi)[2] %>% as.numeric() %>% round(2),
-                 st_bbox(aoi)[3] %>% as.numeric() %>% round(2), sep = "/")
+  bounds = paste(sf::st_bbox(aoi)[4] %>% as.numeric() %>% round(2),
+                 sf::st_bbox(aoi)[1] %>% as.numeric() %>% round(2),
+                 sf::st_bbox(aoi)[2] %>% as.numeric() %>% round(2),
+                 sf::st_bbox(aoi)[3] %>% as.numeric() %>% round(2), sep = "/")
 
   # Setup request
   request <- list("dataset_short_name" = 'reanalysis-era5-land',
@@ -86,7 +86,7 @@ era5land_download_hourly <- function(aoi = aoi,
                   "format" = format,
                   "target" = target)
 
-  file <- wf_request(user     = user,
+  file <- ecmwfr::wf_request(user     = user,
                      request  = request,
                      transfer = TRUE,
                      path     = download_dir)
@@ -122,7 +122,7 @@ era5land_download_monthly <- function(aoi = aoi,
 
   ### AUTHENTICATE ####
 
-  wf_set_key(user = user,
+  ecmwfr::wf_set_key(user = user,
              key = key,
              service = "cds")
 
@@ -145,10 +145,10 @@ era5land_download_monthly <- function(aoi = aoi,
 
   # FORMAT BOUNDS
 
-  bounds = paste(st_bbox(aoi)[4] %>% as.numeric() %>% round(0),
-                 st_bbox(aoi)[1] %>% as.numeric() %>% round(0),
-                 st_bbox(aoi)[2] %>% as.numeric() %>% round(0),
-                 st_bbox(aoi)[3] %>% as.numeric() %>% round(0), sep = "/")
+  bounds = paste(sf::st_bbox(aoi)[4] %>% as.numeric() %>% round(0),
+                 sf::st_bbox(aoi)[1] %>% as.numeric() %>% round(0),
+                 sf::st_bbox(aoi)[2] %>% as.numeric() %>% round(0),
+                 sf::st_bbox(aoi)[3] %>% as.numeric() %>% round(0), sep = "/")
 
   # Setup request
   request <- list("dataset_short_name" = 'reanalysis-era5-land-monthly-means',
@@ -161,7 +161,7 @@ era5land_download_monthly <- function(aoi = aoi,
                   "format" = "grib",
                   "target" = target)
 
-  file <- wf_request(user     = user,
+  file <- ecmwfr::wf_request(user     = user,
                      request  = request,
                      transfer = TRUE,
                      path     = download_dir)

--- a/R/download.R
+++ b/R/download.R
@@ -69,10 +69,10 @@ era5land_download_hourly <- function(aoi = aoi,
 
   # FORMAT BOUNDS
 
-  bounds = paste(st_bbox(aoi)[4] %>% as.numeric() %>% round(0),
-                 st_bbox(aoi)[1] %>% as.numeric() %>% round(0),
-                 st_bbox(aoi)[2] %>% as.numeric() %>% round(0),
-                 st_bbox(aoi)[3] %>% as.numeric() %>% round(0), sep = "/")
+  bounds = paste(st_bbox(aoi)[4] %>% as.numeric() %>% round(2),
+                 st_bbox(aoi)[1] %>% as.numeric() %>% round(2),
+                 st_bbox(aoi)[2] %>% as.numeric() %>% round(2),
+                 st_bbox(aoi)[3] %>% as.numeric() %>% round(2), sep = "/")
 
   # Setup request
   request <- list("dataset_short_name" = 'reanalysis-era5-land',

--- a/man/era5land_download_hourly.Rd
+++ b/man/era5land_download_hourly.Rd
@@ -6,7 +6,7 @@
 \usage{
 era5land_download_hourly(
   aoi = aoi,
-  aoi_name = name,
+  aoi_name = "name",
   years = 2021:2021,
   months = 5:8,
   days = 1:31,
@@ -14,7 +14,9 @@ era5land_download_hourly(
   variables = c("surface_net_solar_radiation"),
   user = "",
   key = "",
-  download_dir = "."
+  download_dir = ".",
+  format = c("netcdf", "grib"),
+  ...
 )
 }
 \arguments{
@@ -37,6 +39,11 @@ era5land_download_hourly(
 \item{key}{your api key as a string}
 
 \item{download_dir}{download directory}
+
+\item{format}{format of the data. \code{"netcdf"} (default) or \code{"grib"}}
+
+\item{...}{further parameters passed to \code{\link[ecmwfr:wf_request]{ecmwfr::wf_request()}}
+#'}
 }
 \value{
 A matrix of the infile

--- a/man/era5land_download_monthly.Rd
+++ b/man/era5land_download_monthly.Rd
@@ -11,8 +11,9 @@ era5land_download_monthly(
   months = 5:8,
   variables = c("2m_temperature", "total_precipitation"),
   user = "",
-  key = "",
-  download_dir = "."
+  download_dir = ".",
+  format = c("netcdf", "grib"),
+  ...
 )
 }
 \arguments{
@@ -28,9 +29,12 @@ era5land_download_monthly(
 
 \item{user}{your user id as a string}
 
-\item{key}{your api key as a string}
-
 \item{download_dir}{download directory}
+
+\item{format}{format of the data. \code{"netcdf"} (default) or \code{"grib"}}
+
+\item{...}{further parameters passed to \code{\link[ecmwfr:wf_request]{ecmwfr::wf_request()}}
+#'}
 }
 \value{
 A matrix of the infile


### PR DESCRIPTION
Hi @bevingtona - I made some changes to allow netcdf download (made it the default in fact), as well as a couple of helper functions to simplify authentication and the aoi formatting.

For authorization, `ecmwfr` does cache your key, so you shouldn't have to enter it every time.

Here's an example, just reading in using `stars::read_stars()`:

``` r
library(era5landDownloadTools)
library(sf)
#> Linking to GEOS 3.9.1, GDAL 3.3.2, PROJ 8.1.1
library(stars)
#> Loading required package: abind
#> Registered S3 methods overwritten by 'stars':
#>   method             from
#>   st_bbox.SpatRaster sf  
#>   st_crs.SpatRaster  sf
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(bcmaps)

aoi <- bc_cities(ask = FALSE) %>%
  filter(NAME == "Kamloops") %>%
  st_buffer(dist = 200*1000) %>%
  st_transform(4326)
#> bc_cities was updated on 2021-09-29

years <- 2020:2021
months <- 7:8
days <- 3:4
hours <- 0:23

testera <- era5land_download_hourly(aoi = aoi,
                                    aoi_name = "test",
                                    years = years,
                                    months = months,
                                    days = days,
                                    hours = hours,
                                    variables = c("surface_net_solar_radiation", "2m_temperature"),
                                    user = "105160")
#> Requesting data to the cds service with username 105160
#> - staging data transfer at url endpoint or request id:
#>   43b4d3a2-5d69-44ac-8da1-f08d4b6359f0
#> - timeout set to 1.0 hours
#> - polling server for a data transfer \ polling server for a data transfer
#> - moved temporary file to -> ./ERA5-land-hourly_test_2020-2021y_07-08m_03-04d_00:00-23:00h_2vars.nc
#> - request purged from queue!

read_stars(testera)
#> ssr, t2m,
#> stars object with 3 dimensions and 2 attributes
#> attribute(s):
#>                    Min.      1st Qu.       Median         Mean      3rd Qu.
#> ssr [J/m^2] 174814.0000 2361019.9772 3159915.2350 6438591.0191 9072330.6668
#> t2m [K]        270.4822     284.1735     288.4363     288.6776     293.2696
#>                     Max. NA's
#> ssr [J/m^2] 2.781684e+07 1872
#> t2m [K]     3.071355e+02 1872
#> dimension(s):
#>      from  to  offset delta  refsys point                             values
#> x       1  57 -123.24   0.1      NA    NA                               NULL
#> y       1  36   52.41  -0.1      NA    NA                               NULL
#> time    1 144      NA    NA POSIXct    NA 2020-07-03,...,2021-07-04 23:00:00
#>      x/y
#> x    [x]
#> y    [y]
#> time
```

<sup>Created on 2021-10-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>